### PR TITLE
Event description text parsing. Can now add extra data for facebook links

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -21,11 +21,15 @@ calendar_url: https://calendar.google.com/calendar/embed?src=kg5v9k480jn2qahpmq3
 
 <div class="calendar-container">
   <div class="calendar-event" id="calendar-event">
-      <h1 id="event-close"><a href="#">&times;</a></h1>
+      
       <h2 class="event-tag event-tag-title">Event:</h2> <span class="event-text" id="event-text-title"></span><br>
       <h2 class="event-tag event-tag-date">Date:</h2> <span class="event-text" id="event-text-date"></span><br>
       <h2 class="event-tag event-tag-location">Location:</h2> <span class="event-text" id="event-text-location"></span><br>
       <h2 class="event-tag event-tag-description">More info:</h2> <span class="event-text" id="event-text-description"></span><br>
+      <div class="event-buttons">
+        <button class="calendar-button" id="facebook-link">Go to Facebook Event</button>
+        <button class="calendar-button" id="event-close">Close</button>
+      </div>
   </div>
   <div class="calendar" id="css-calendar"></div>
 </div>

--- a/css/calendar.scss
+++ b/css/calendar.scss
@@ -41,19 +41,6 @@
   margin-bottom: 10px;
   display: none;
 
-  #event-close {
-    display: block;
-    position: abolsute;
-    float: right;
-    margin: 5px;
-    transform: translateY(-10px);
-
-    a {
-      text-decoration: none;
-      color: black;
-    }
-  }
-
   h2, p { 
     color: black;
     text-align: left;
@@ -71,10 +58,14 @@
 
   .event-text {
     display: inline-block;
-    width: 65%;
+    width: 70%;
     margin-top: 10px;
     margin-bottom: 10px;
     vertical-align: middle;
+  }
+
+  .event-buttons {
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
Google Calendar Events: 
use <desc> tag for description text, if none used, whole desc text is used.
use <fb> tag for a facebook event link